### PR TITLE
Add support for a custom endpoint and prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,21 @@ The AWS bucket that the files will be uploaded to.
 
 *Default:* `undefined`
 
-### region (`required`)
+### region
 
 The region the AWS `bucket` is located in.
+
+*Default:* `undefined`
+
+### prefix
+
+A path to upload your files to within the bucket.
+
+*Default:* `undefined`
+
+### endpoint
+
+A full path where the S3 compatible service (ie. Minio, Digital Ocean Spaces) resides. When an endpoint is specified a region is no longer required.
 
 *Default:* `undefined`
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
         distDir: function(context) {
           return context.distDir;
         },
+        endpoint: undefined,
         revisionKey: function(context) {
           return (
             context.commandOptions.revision ||
@@ -56,7 +57,8 @@ module.exports = {
           new AWS.S3({
             region: this.readConfig('region'),
             accessKeyId: this.readConfig('accessKeyId'),
-            secretAccessKey: this.readConfig('secretAccessKey')
+            secretAccessKey: this.readConfig('secretAccessKey'),
+            endpoint: this.readConfig('endpoint')
           });
 
         return this._upload(self.s3)
@@ -77,7 +79,8 @@ module.exports = {
           new AWS.S3({
             region: this.readConfig('region'),
             accessKeyId: this.readConfig('accessKeyId'),
-            secretAccessKey: this.readConfig('secretAccessKey')
+            secretAccessKey: this.readConfig('secretAccessKey'),
+            endpoint: this.readConfig('endpoint')
           });
 
         this.log(`preparing to activate ${revisionKey}`, {


### PR DESCRIPTION
The custom endpoint allows you to use object storage that's compatible with the AWS S3 API, such as [Minio](https://minio.io/) or Digital Ocean's new product [Spaces](https://www.digitalocean.com/products/object-storage/). Everything else works the same, but you specific a url for this property. I've been able to get it to work with Spaces on this fork.

The prefix property allows you to specify a nested folder as the destination for the app instead of the root of a bucket.

Please let me know if you'd like to see anything added or changed.

Cheers!