### PR TITLE
Fix #22

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = {
         });
 
         let _this = this;
-        return this.fetchRevisions(context).then(function(revisions) {
+        return this.fetchRevision(context).then(function(revisions) {
            let found = revisions.revisions.map(function(element) { return element.revision; }).indexOf(revisionKey);
            if (found >= 0) {
 
@@ -126,8 +126,8 @@ module.exports = {
         }
       },
 
-      fetchRevisions(context) {
-        return this._list(context)
+      fetchRevision(context) {
+        return this._head(context)
           .then(function(revisions) {
             return {
               revisions: revisions
@@ -135,19 +135,21 @@ module.exports = {
           });
       },
 
-      _list(/* context */) {
+      _head(/* context */) {
         const bucket = this.readConfig('bucket');
         const deployArchive = this.readConfig('deployArchive');
         const archiveExt = `.${this.readConfig('archiveType')}`;
         const deployInfo = this.readConfig('deployInfo');
         const prefix = this.readConfig('prefix');
+        const revisionKey = this.readConfig('revisionKey');
         const archivePath = prefix ? [prefix, deployArchive].join('/') : deployArchive;
         const indexKey = prefix ? [prefix, deployInfo].join('/') : deployInfo;
 
         let revisionPrefix = `${archivePath}-`;
+        const revisionPath = `${revisionPrefix}${revisionKey}.${archiveExt}`;
 
         return RSVP.hash({
-          revisions: this.listObjects(this.s3, { Bucket: bucket, Prefix: revisionPrefix }),
+          revisions: this.headObject(this.s3, { Bucket: bucket, Key: revisionPath }),
           current: this.getObject(this.s3, { Bucket: bucket, Key: indexKey }),
         })
         .then(function(data) {
@@ -162,7 +164,7 @@ module.exports = {
             }
           }
 
-          let results = data.revisions.Contents.sort(function(a, b) {
+          let results = data.revisions.sort(function(a, b) {
             return new Date(b.LastModified) - new Date(a.LastModified);
           }).map(function(d) {
             let revision = '';
@@ -181,13 +183,14 @@ module.exports = {
         }).catch(this._errorMessage.bind(this));
       },
 
-      listObjects(s3, params) {
-        return new RSVP.Promise(function(resolve, reject) {
-          s3.listObjects(params, function(err, data) {
+      headObject(s3, params) {
+        return new RSVP.Promise(function(resolve) {
+          s3.headObject(params, function(err, data) {
             if (err) {
-              return reject(err);
+              // revision not found
+              return resolve([]);
             }
-            return resolve(data);
+            return resolve([data]);
           });
         });
       },

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ module.exports = {
         const indexKey = prefix ? [prefix, deployInfo].join('/') : deployInfo;
 
         let revisionPrefix = `${archivePath}-`;
-        const revisionPath = `${revisionPrefix}${revisionKey}.${archiveExt}`;
+        const revisionPath = `${revisionPrefix}${revisionKey}${archiveExt}`;
 
         return RSVP.hash({
           revisions: this.headObject(this.s3, { Bucket: bucket, Key: revisionPath }),

--- a/index.js
+++ b/index.js
@@ -169,8 +169,8 @@ module.exports = {
           }).map(function(d) {
             let revision = '';
             /* Check that this is the type of configured archive. */
-            if (d.Key.lastIndexOf(archiveExt) !== -1) {
-              revision = d.Key.substring(revisionPrefix.length, d.Key.lastIndexOf('.'));
+            if (revisionPath.lastIndexOf(archiveExt) !== -1) {
+              revision = revisionPath.substring(revisionPrefix.length, revisionPath.lastIndexOf('.'));
             }
             let active = data.current && revision === activeRevision;
             return { revision: revision, timestamp: d.LastModified, active: active, deployer: 'fastboot-s3' };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-cli-deploy-fastboot-s3",
+  "name": "@outdoorsyco/ember-cli-deploy-fastboot-s3",
   "version": "0.3.7",
   "description": "An ember-cli-deploy plugin that archives and uploads FastBoot build to AWS S3.",
   "keywords": [
@@ -19,9 +19,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/he9qi/ember-cli-deploy-fastboot-s3.git"
+    "url": "https://github.com/outdoorsy/ember-cli-deploy-fastboot-s3.git"
   },
-  "author": "Qi He <qhe@heyook.com>",
+  "author": "Outdoorsy",
   "license": "MIT",
   "dependencies": {
     "archiver": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@outdoorsyco/ember-cli-deploy-fastboot-s3",
+  "name": "ember-cli-deploy-fastboot-s3",
   "version": "0.3.7",
   "description": "An ember-cli-deploy plugin that archives and uploads FastBoot build to AWS S3.",
   "keywords": [
@@ -19,9 +19,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/outdoorsy/ember-cli-deploy-fastboot-s3.git"
+    "url": "https://github.com/he9qi/ember-cli-deploy-fastboot-s3.git"
   },
-  "author": "Outdoorsy",
+  "author": "Qi He <qhe@heyook.com>",
   "license": "MIT",
   "dependencies": {
     "archiver": "4.0.1",

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -36,12 +36,12 @@ describe('fastboot-s3 plugin', () => {
           }
         };
       },
-      listObjects: function() {
+      headObject: function(){
         return {
           promise: function() {
             return RSVP.Promise.resolve();
           }
-        };
+        }
       }
     };
     subject = require('../../index');
@@ -387,15 +387,10 @@ describe('fastboot-s3 plugin', () => {
               }
             };
           },
-          listObjects: (s3, callback) => {
+          headObject: (s3, callback) => {
             callback(null,
               {
-                Contents: [
-                  {Key: 'some prefix/fastboot-deploy-info.json', LastModified: new Date()},
-                  {Key: 'some prefix/dist-123456.zip', LastModified: new Date()},
-                  {Key: 'some prefix/dist-revABCD.zip', LastModified: new Date()},
-                  {Key: 'some prefix/dist-349456.zip', LastModified: new Date()}
-                ]
+                LastModified: new Date(),
               }
             );
           },


### PR DESCRIPTION
Fixes issue #22 by using `headObject` instead of `listObjects`. Tried to implement it by changing as little code as possible, which is why we still keep `revisions` as an array.